### PR TITLE
correct bug in candidateProfile router

### DIFF
--- a/server/routes/candidateProfile.router.js
+++ b/server/routes/candidateProfile.router.js
@@ -41,7 +41,7 @@ router.post('/profile', (req, res) => {
   (user_id, first_name, last_name,email,linkedin_link, resume_path, cover_letter_path) 
   VALUES ($1, $2, $3, $4, $5, $6,$7)`;
     const sqlParam = [
-      req.user.user_info.id,
+      req.user.id,
       req.body.FirstName,
       req.body.LastName,
       req.body.Email,


### PR DESCRIPTION
correct bug in candidateProfile router when new candidate completes profile. 
post candidateProfile req.user.user_info.id was throwing error null.
post candidateProfile router change from req.user.user_info.id to req.user.id.