### PR TITLE
logic added to prevent employer from posting jobs when profile is not…

### DIFF
--- a/src/components/EmployerForm/EmployerForm.jsx
+++ b/src/components/EmployerForm/EmployerForm.jsx
@@ -45,13 +45,13 @@ function EmployerForm() {
 
     return (
         <form onSubmit={handleSubmit}>
-            <TextField value={companyName} onChange={(event) => {setCompanyName(event.target.value)} } label="company name" />
-            <TextField value={companyAddress} onChange={(event) => { setCompanyAddress(event.target.value) }} label="company address" />
-            <TextField value={companyPhone} onChange={(event) => { setCompanyPhone(event.target.value) }} label="company phone number" />
-            <TextField value={companyEmail} onChange={(event) => { setCompanyEmail(event.target.value) }} label="company email" />
-            <TextField value={companyLink} onChange={(event) => { setCompanyLink(event.target.value) }} label="company site link" />
-            <TextField value={companyLogoPath} onChange={(event) => { setCompanyLogoPath(event.target.value) }} label="company logo upload" />
-            <TextField value={companyDescription} onChange={(event) => { setCompanyDescription(event.target.value) }} label="company description" />
+            <TextField required value={companyName} onChange={(event) => {setCompanyName(event.target.value)} } label="company name" />
+            <TextField required value={companyAddress} onChange={(event) => { setCompanyAddress(event.target.value) }} label="company address" />
+            <TextField required value={companyPhone} onChange={(event) => { setCompanyPhone(event.target.value) }} label="company phone number" />
+            <TextField required value={companyEmail} onChange={(event) => { setCompanyEmail(event.target.value) }} label="company email" />
+            <TextField required value={companyLink} onChange={(event) => { setCompanyLink(event.target.value) }} label="company site link" />
+            <TextField required value={companyLogoPath} onChange={(event) => { setCompanyLogoPath(event.target.value) }} label="company logo upload" />
+            <TextField required value={companyDescription} onChange={(event) => { setCompanyDescription(event.target.value) }} label="company description" />
             <Button type='submit' variant='contained'>submit</Button>
         </form>
     );

--- a/src/components/Nav/Nav.jsx
+++ b/src/components/Nav/Nav.jsx
@@ -28,6 +28,7 @@ function Nav() {
     setAnchorEl(null);
   }
 
+  console.log(user);
 
   return (
     <div className="nav">
@@ -63,8 +64,20 @@ function Nav() {
           </Link>
         )}
 
-        {/* If a user is logged in, show these links */}
-        {user.user_type === 'employer' && (
+        {/* if user type is employer AND their user_info is null,
+         ie. haven't filled out their required inputs, only allow them to do so until they complete it */}
+        {(user.user_type === 'employer' && user.user_info === null) && (
+          <>
+            <Link className="navLink" to="/user">
+              Employer Profile
+            </Link>
+
+            <LogOutButton className="navLink" />
+          </>
+        )}
+
+        {/* if the user type is employer AND they have completed their profile, they can post jobs and edit their profile! */}
+        {(user.user_type === 'employer' && user.user_info != null) && (
           <>
             <Link className="navLink" to="/user">
               Employer Profile


### PR DESCRIPTION
I added logic to nav bar rendering to prevent the employer from easily posting jobs when their employer table is not complete. Once it's NOT NULL, they can edit their employer table AND post jobs etc. Maybe we redefine what user is in passport for candidate users and do a similar thing with multiple &&'s? Like {(user.user_type === 'candidate' && user.education != null && user.experience. !=null && ...) && (RENDER OPTIONS TO DO STUFF).

Don't merge till 1/5/22 to discuss.