### PR TITLE
correct magic button for jobPost

### DIFF
--- a/src/components/PostJob/PostJob.jsx
+++ b/src/components/PostJob/PostJob.jsx
@@ -132,6 +132,16 @@ function PostJob() {
 
         });
 
+        dispatch({
+            type: 'UPDATE_EDIT_JOB',
+            payload: { title: form.jobTitle.value }
+        })
+
+        dispatch({
+            type: 'UPDATE_EDIT_JOB',
+            payload: { description: form.jobDescription.value }
+        })
+
     }
 
 


### PR DESCRIPTION
correction for jobPost. no longer need to hit space bar. just click on post new position twice.